### PR TITLE
Playlist dropout – Wrap player iframes in visually-hidden wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,9 @@
         <div id="beatreset">
           <img src="images/reset.png" class="reset btn"/>
         </div>
-        <div id="beatvideo"></div>
+        <div class="visually-hidden">
+          <div id="beatvideo"></div>
+        </div>
         <div id="beatvolume">
           <input id="beatslider"
             type="range"
@@ -135,7 +137,9 @@
       </div>
 
       <div id="speechplayer">
-        <div id="speechvideo"></div>
+        <div class="visually-hidden">
+          <div id="speechvideo"></div>
+        </div>
         <div id="speechvolume">
           <input id="speechslider"
             type="range"

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -18,7 +18,7 @@ $.urlParam = function(name) {
                 .exec(window.location.href);
   console.log(name);
   console.log(results);
-  return results [1] || 0;
+  return (results) ? results[1] : 0;
 };
 
 
@@ -965,6 +965,7 @@ $('#speechslider').on('change', function () {
 
 // Play & Pause
 $('#playpausebutton img').on('click', function () {
+  if (!beatPlayer) return;
   var beatPlayerState = beatPlayer.getPlayerState();
   var speechPlayerState = speechPlayer.getPlayerState();
   var button = document.getElementById("buttonicon");
@@ -990,6 +991,7 @@ $('#playpausebutton img').on('click', function () {
 
 // Next video
 $('#beatreset img').on('click', function () {
+  if (!beatPlayer) return;
   if (beatOrder[beatOrder.length - 1] === currentBeatId) {
     beatPlayer.playVideoAt(0);
   } else {
@@ -1002,6 +1004,7 @@ $('#beatreset img').on('click', function () {
 });
 
 $('#speechreset img').on('click', function () {
+  if (!speechPlayer) return;
     if (speechOrder[speechOrder.length - 1] === currentSpeechId) {
       speechPlayer.playVideoAt(0);
     } else {
@@ -1045,12 +1048,15 @@ function onBeatStateChange() {
       event.target.setPlaybackQuality('small');
   }
   const index = beatPlayer.getPlaylistIndex();
+  console.log('Beat playlist index: ', index);
   const key = beatOrder[index];
   const object = beatArray[key];
   currentBeatId = key;
-  var BeatTitle = document.getElementById("BeatTitle");
-  BeatTitle.innerHTML = object.title;
-  BeatTitle.href = object.url;
+  if (object) {
+    var BeatTitle = document.getElementById("BeatTitle");
+    BeatTitle.innerHTML = object.title;
+    BeatTitle.href = object.url;
+  }
   linkBuilder();
 }
 
@@ -1059,12 +1065,15 @@ function onSpeechStateChange() {
       event.target.setPlaybackQuality('small');
   }
   const index = speechPlayer.getPlaylistIndex();
+  console.log('Speech playlist index: ', index);
   const key = speechOrder[index];
   const object = speechArray[key];
   currentSpeechId = key;
-  var SpeechTitle = document.getElementById("SpeechTitle");
-  SpeechTitle.innerHTML = object.title;
-  SpeechTitle.href = object.url;
+  if (object) {
+    var SpeechTitle = document.getElementById("SpeechTitle");
+    SpeechTitle.innerHTML = object.title;
+    SpeechTitle.href = object.url;
+  }
   linkBuilder();
 }
 

--- a/style.css
+++ b/style.css
@@ -283,16 +283,10 @@ HTML{
 }
 
 #speechvideo{
-	display: none;
-	position: absolute;
-	/* visibility: hidden; */
 	z-index: 0;
 }
 
 #beatvideo{
-	display: none;
-	position: absolute;
-	visibility: hidden;
 	z-index: 0;
 }
 
@@ -618,4 +612,15 @@ studiologo a{
 			max-width: 231px;
 		}
 
+}
+
+.visually-hidden {
+	border: 0; 
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	position: absolute; 
+	width: 1px; 
+  clip: rect(0 0 0 0); 
+  overflow: hidden; 
 }


### PR DESCRIPTION
So this was a pretty odd one, man. After an indiscriminate period, either player would drop out and return `-1` for its `getPlaylistIndex()` call (not something documented in the YouTube API). From that point onwards, picking an item out of `beatOrder` or `speechOrder` arrays is borked.

Looks like you were onto something re: player visibility. As soon as the players are wrapped in `visually-hidden` containers instead of `display: none`, I couldn't replicate the issue. Added a log so you can track the playlist as it progresses. Have a go 👌 

Plus:
+ Misc error handling for players before initialised
+ Error handling on `$.urlParam`

Side note: Videos that are unavailable don't play or progress the playlist, so can appear broken. That might be something to look into another time.